### PR TITLE
Fix relative paths.

### DIFF
--- a/src/Console/GenerateFormRequestsCommand.php
+++ b/src/Console/GenerateFormRequestsCommand.php
@@ -24,8 +24,7 @@ class GenerateFormRequestsCommand extends Command
                             {--output=./app/Http/Requests : Output directory for generated FormRequest classes}
                             {--namespace=App\\Http\\Requests : PHP namespace for generated classes}
                             {--force : Overwrite existing FormRequest files}
-                            {--dry-run : Show what would be generated without creating files}
-                            {--verbose : Enable verbose output}';
+                            {--dry-run : Show what would be generated without creating files}';
 
     /**
      * The console command description.
@@ -42,7 +41,7 @@ class GenerateFormRequestsCommand extends Command
         $namespace = $this->option('namespace');
         $force = $this->option('force');
         $dryRun = $this->option('dry-run');
-        $verbose = $this->option('verbose');
+        $verbose = $this->getOutput()->isVerbose();
 
         try {
             // Initialize services

--- a/src/Parser/OpenApiParser.php
+++ b/src/Parser/OpenApiParser.php
@@ -36,16 +36,22 @@ class OpenApiParser
         }
 
         try {
-            // Detect format from file extension
-            $format = $this->detectFormat($filePath);
-
-            if ($format === 'yaml') {
-                $spec = Reader::readFromYamlFile($filePath);
-            } else {
-                $spec = Reader::readFromJsonFile($filePath);
+            // Convert to absolute path to handle references properly
+            $absolutePath = realpath($filePath);
+            if ($absolutePath === false) {
+                throw new InvalidArgumentException("Unable to resolve absolute path for: {$filePath}");
             }
 
-            return $this->parseOpenApiSpec($spec, $filePath);
+            // Detect format from file extension
+            $format = $this->detectFormat($absolutePath);
+
+            if ($format === 'yaml') {
+                $spec = Reader::readFromYamlFile($absolutePath);
+            } else {
+                $spec = Reader::readFromJsonFile($absolutePath);
+            }
+
+            return $this->parseOpenApiSpec($spec, $absolutePath);
         } catch (Throwable $e) {
             throw new InvalidArgumentException(
                 "Failed to parse OpenAPI specification from {$filePath}: " . $e->getMessage(),

--- a/tests/contract/CliInterfaceTest.php
+++ b/tests/contract/CliInterfaceTest.php
@@ -97,18 +97,19 @@ class CliInterfaceTest extends TestCase
         $this->assertStringContainsString('Show what would be generated without creating files', $signature);
     }
 
-    public function test_command_has_verbose_option()
+    public function test_command_supports_verbose_option()
     {
         $command = new GenerateFormRequestsCommand;
 
-        // Get the signature and check if it contains the verbose option
-        $reflection = new ReflectionClass($command);
-        $signatureProperty = $reflection->getProperty('signature');
-        $signatureProperty->setAccessible(true);
-        $signature = $signatureProperty->getValue($command);
+        // Test that the command can handle Symfony's built-in verbose option
+        // Symfony Console automatically provides -v, -vv, -vvv options
+        $definition = $command->getDefinition();
 
-        $this->assertStringContainsString('--verbose', $signature);
-        $this->assertStringContainsString('Enable verbose output', $signature);
+        // Verify the command extends Laravel's Command class which supports verbose
+        $this->assertInstanceOf(\Illuminate\Console\Command::class, $command);
+
+        // Verify the command can access output verbosity (this is built-in Symfony functionality)
+        $this->assertTrue(method_exists($command, 'getOutput'));
     }
 
     public function test_command_returns_success_response_structure()

--- a/tests/unit/Console/GenerateFormRequestsCommandTest.php
+++ b/tests/unit/Console/GenerateFormRequestsCommandTest.php
@@ -301,10 +301,10 @@ describe('GenerateFormRequestsCommand', function () {
             $inputMock->shouldReceive('getOption')->with('namespace')->andReturn('App\\Http\\Requests');
             $inputMock->shouldReceive('getOption')->with('force')->andReturn(false);
             $inputMock->shouldReceive('getOption')->with('dry-run')->andReturn(false);
-            $inputMock->shouldReceive('getOption')->with('verbose')->andReturn(false);
 
             $outputMock->shouldReceive('writeln')->andReturn(null);
             $outputMock->shouldReceive('write')->andReturn(null);
+            $outputMock->shouldReceive('isVerbose')->andReturn(false);
 
             $this->command->setInput($inputMock);
             $this->command->setOutput($outputMock);
@@ -331,10 +331,10 @@ describe('GenerateFormRequestsCommand', function () {
             $inputMock->shouldReceive('getOption')->with('namespace')->andReturn('App\\Http\\Requests');
             $inputMock->shouldReceive('getOption')->with('force')->andReturn(false);
             $inputMock->shouldReceive('getOption')->with('dry-run')->andReturn(false);
-            $inputMock->shouldReceive('getOption')->with('verbose')->andReturn(false);
 
             $outputMock->shouldReceive('writeln')->andReturn(null);
             $outputMock->shouldReceive('write')->andReturn(null);
+            $outputMock->shouldReceive('isVerbose')->andReturn(false);
 
             $this->command->setInput($inputMock);
             $this->command->setOutput($outputMock);
@@ -359,10 +359,10 @@ describe('GenerateFormRequestsCommand', function () {
             $inputMock->shouldReceive('getOption')->with('namespace')->andReturn('App\\Http\\Requests');
             $inputMock->shouldReceive('getOption')->with('force')->andReturn(false);
             $inputMock->shouldReceive('getOption')->with('dry-run')->andReturn(false);
-            $inputMock->shouldReceive('getOption')->with('verbose')->andReturn(false);
 
             $outputMock->shouldReceive('writeln')->andReturn(null);
             $outputMock->shouldReceive('write')->andReturn(null);
+            $outputMock->shouldReceive('isVerbose')->andReturn(false);
 
             $this->command->setInput($inputMock);
             $this->command->setOutput($outputMock);

--- a/tests/unit/Parser/OpenApiParserTest.php
+++ b/tests/unit/Parser/OpenApiParserTest.php
@@ -85,6 +85,24 @@ describe('OpenApiParser', function () {
 
             unlink($tempFile);
         });
+
+        it('should handle relative paths correctly', function () {
+            // Create a temporary file in the current directory
+            $relativePath = 'temp_openapi_test.json';
+            file_put_contents($relativePath, json_encode([
+                'openapi' => '3.0.0',
+                'info' => ['title' => 'Test', 'version' => '1.0.0'],
+                'paths' => [],
+            ]));
+
+            // Test parsing with relative path
+            $specification = $this->parser->parseFromFile($relativePath);
+            expect($specification->version)->toBe('3.0.0');
+            expect($specification->info['title'])->toBe('Test');
+
+            // Clean up
+            unlink($relativePath);
+        });
     });
 
     describe('extractEndpoints', function () {


### PR DESCRIPTION
Fix issue with duplicate verbose flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - OpenAPI specs can now be parsed from relative file paths reliably.

- Improvements
  - More robust error handling during spec parsing with clearer messages on failures.
  - Parser now resolves files using absolute paths for consistent behavior.

- Changes
  - Console command verbosity now follows standard -v/-vv/-vvv flags; the custom --verbose option has been removed.

- Bug Fixes
  - Addressed issues related to path handling that could cause parsing inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->