### PR TITLE
Fixed bug causing directories to be created on dry-run

### DIFF
--- a/src/Console/GenerateFormRequestsCommand.php
+++ b/src/Console/GenerateFormRequestsCommand.php
@@ -60,7 +60,7 @@ class GenerateFormRequestsCommand extends Command
             }
 
             // Validate inputs
-            $validationResult = $this->validateInputs($specPath, $outputDir, $namespace);
+            $validationResult = $this->validateInputs($specPath, $outputDir, $namespace, $dryRun);
             if (! $validationResult['success']) {
                 $this->error($validationResult['message']);
 
@@ -162,7 +162,7 @@ class GenerateFormRequestsCommand extends Command
     /**
      * Validate command inputs
      */
-    private function validateInputs(string $specPath, string $outputDir, string $namespace): array
+    private function validateInputs(string $specPath, string $outputDir, string $namespace, bool $dryRun = false): array
     {
         // Check spec file exists
         if (! file_exists($specPath)) {
@@ -185,6 +185,11 @@ class GenerateFormRequestsCommand extends Command
                 'success' => false,
                 'message' => "Invalid namespace format: {$namespace}",
             ];
+        }
+
+        // Skip directory validation and creation in dry-run mode
+        if ($dryRun) {
+            return ['success' => true];
         }
 
         // Check if output directory is writable (create if needed)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dry-run mode now skips output directory validation and creation, allowing commands to simulate execution without making filesystem changes. Normal execution remains unchanged.

- Tests
  - Added unit tests to verify directory handling differs between dry-run and normal modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->