### PR TITLE
Add OpenAPI 3.1 union type support for nullable fields

### DIFF
--- a/src/Models/SchemaObject.php
+++ b/src/Models/SchemaObject.php
@@ -340,7 +340,7 @@ class SchemaObject
             } elseif (is_array($schema['type'])) {
                 // OpenAPI 3.1 format: type: ["string", "null"]
                 $unionTypes = $schema['type'];
-                $nonNullTypes = array_filter($unionTypes, fn ($t) => $t !== 'null');
+                $nonNullTypes = array_filter($unionTypes, fn ($t): bool => $t !== 'null');
 
                 if (in_array('null', $unionTypes)) {
                     $nullable = true;

--- a/src/Models/SchemaObject.php
+++ b/src/Models/SchemaObject.php
@@ -21,7 +21,8 @@ class SchemaObject
         public readonly ?ValidationConstraints $validation = null,
         public readonly ?string $ref = null,
         public readonly string $title = '',
-        public readonly string $description = ''
+        public readonly string $description = '',
+        public readonly bool $nullable = false
     ) {
         $this->validateType();
         $this->validateStructure();
@@ -53,8 +54,11 @@ class SchemaObject
             $validation = ValidationConstraints::fromSchema($schema);
         }
 
+        // Parse type and nullable from OpenAPI 3.0/3.1 formats
+        $typeInfo = self::parseTypeAndNullable($schema);
+
         return new self(
-            type: self::validateString($schema['type'] ?? 'string') ?? 'string',
+            type: $typeInfo['type'],
             format: self::validateString($schema['format'] ?? null),
             properties: $properties,
             items: $items,
@@ -62,7 +66,8 @@ class SchemaObject
             validation: $validation,
             ref: self::validateString($schema['$ref'] ?? null),
             title: self::validateString($schema['title'] ?? '') ?? '',
-            description: self::validateString($schema['description'] ?? '') ?? ''
+            description: self::validateString($schema['description'] ?? '') ?? '',
+            nullable: $typeInfo['nullable']
         );
     }
 
@@ -288,6 +293,78 @@ class SchemaObject
     }
 
     /**
+     * Check if this schema is nullable (OpenAPI 3.0 nullable: true or 3.1 union with null)
+     */
+    public function isNullable(): bool
+    {
+        return $this->nullable;
+    }
+
+    /**
+     * Check if this uses union type syntax
+     */
+    public function hasUnionType(): bool
+    {
+        return $this->nullable && ! $this->isReference();
+    }
+
+    /**
+     * Get the primary type (non-null type from union or regular type)
+     */
+    public function getPrimaryType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Parse type and nullable from OpenAPI schema
+     *
+     * @param  array<string, mixed>  $schema
+     * @return array{type: string, nullable: bool}
+     */
+    private static function parseTypeAndNullable(array $schema): array
+    {
+        $type = 'string'; // default
+        $nullable = false;
+
+        // Handle OpenAPI 3.0 nullable property
+        if (isset($schema['nullable']) && $schema['nullable'] === true) {
+            $nullable = true;
+        }
+
+        // Handle both single type and union type (OpenAPI 3.1)
+        if (isset($schema['type'])) {
+            if (is_string($schema['type'])) {
+                // OpenAPI 3.0 format: type: "string"
+                $type = self::validateString($schema['type']) ?? 'string';
+            } elseif (is_array($schema['type'])) {
+                // OpenAPI 3.1 format: type: ["string", "null"]
+                $unionTypes = $schema['type'];
+                $nonNullTypes = array_filter($unionTypes, fn ($t) => $t !== 'null');
+
+                if (in_array('null', $unionTypes)) {
+                    $nullable = true;
+                }
+
+                if (count($nonNullTypes) === 1) {
+                    $type = self::validateString(reset($nonNullTypes)) ?? 'string';
+                } elseif (count($nonNullTypes) === 0) {
+                    // Only null type, default to string but nullable
+                    $type = 'string';
+                } else {
+                    // Complex union type not supported, use first non-null type
+                    $type = self::validateString(reset($nonNullTypes)) ?? 'string';
+                }
+            }
+        }
+
+        return [
+            'type' => $type,
+            'nullable' => $nullable,
+        ];
+    }
+
+    /**
      * Validate type is supported
      */
     private function validateType(): void
@@ -385,6 +462,10 @@ class SchemaObject
             $array['description'] = $this->description;
         }
 
+        if ($this->nullable) {
+            $array['nullable'] = $this->nullable;
+        }
+
         return $array;
     }
 
@@ -459,7 +540,8 @@ class SchemaObject
             validation: $this->validation, // ValidationConstraints should be immutable
             ref: $this->ref,
             title: $this->title,
-            description: $this->description
+            description: $this->description,
+            nullable: $this->nullable
         );
     }
 

--- a/tests/unit/Generator/ValidationRuleMapperTest.php
+++ b/tests/unit/Generator/ValidationRuleMapperTest.php
@@ -486,4 +486,269 @@ describe('ValidationRuleMapper', function (): void {
             expect($rule)->toContain('regex:/^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/');
         });
     });
+
+    describe('OpenAPI 3.1 Union Type Support', function (): void {
+        describe('nullable union types', function (): void {
+            it('should map union type string with null to nullable string', function (): void {
+                $schema = new SchemaObject(
+                    type: 'string',
+                    nullable: true
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema, 'name');
+
+                expect($rules)->toHaveKey('name');
+                expect($rules['name'])->toContain('nullable');
+                expect($rules['name'])->toContain('string');
+                expect($rules['name'])->toStartWith('nullable');
+            });
+
+            it('should map union type integer with null to nullable integer', function (): void {
+                $schema = new SchemaObject(
+                    type: 'integer',
+                    nullable: true
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema, 'count');
+
+                expect($rules)->toHaveKey('count');
+                expect($rules['count'])->toContain('nullable');
+                expect($rules['count'])->toContain('integer');
+                expect($rules['count'])->toStartWith('nullable');
+            });
+
+            it('should map union type array with null to nullable array', function (): void {
+                $schema = new SchemaObject(
+                    type: 'array',
+                    items: new SchemaObject(type: 'string'),
+                    nullable: true
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema, 'tags');
+
+                expect($rules)->toHaveKey('tags');
+                expect($rules['tags'])->toContain('nullable');
+                expect($rules['tags'])->toContain('array');
+                expect($rules['tags'])->toStartWith('nullable');
+            });
+
+            it('should handle object with nullable union type properties', function (): void {
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'required_name' => new SchemaObject(type: 'string'),
+                        'nullable_bio' => new SchemaObject(type: 'string', nullable: true),
+                        'nullable_age' => new SchemaObject(type: 'integer', nullable: true),
+                    ],
+                    required: ['required_name']
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema);
+
+                expect($rules)->toHaveKey('required_name');
+                expect($rules)->toHaveKey('nullable_bio');
+                expect($rules)->toHaveKey('nullable_age');
+
+                expect($rules['required_name'])->toContain('required');
+                expect($rules['required_name'])->not->toContain('nullable');
+
+                expect($rules['nullable_bio'])->toContain('nullable');
+                expect($rules['nullable_bio'])->not->toContain('required');
+
+                expect($rules['nullable_age'])->toContain('nullable');
+                expect($rules['nullable_age'])->toContain('integer');
+            });
+
+            it('should handle required nullable fields correctly', function (): void {
+                // In OpenAPI, a field can be both required and nullable
+                // This means the field must be present but can have null value
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'required_nullable' => new SchemaObject(type: 'string', nullable: true),
+                    ],
+                    required: ['required_nullable']
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema);
+
+                expect($rules)->toHaveKey('required_nullable');
+                expect($rules['required_nullable'])->toContain('required');
+                expect($rules['required_nullable'])->not->toContain('nullable');
+            });
+        });
+
+        describe('backward compatibility', function (): void {
+            it('should generate identical rules for OpenAPI 3.0 and 3.1 nullable strings', function (): void {
+                // OpenAPI 3.0 style
+                $schema30 = new SchemaObject(
+                    type: 'string',
+                    nullable: true
+                );
+
+                // OpenAPI 3.1 style (simulated by setting nullable: true)
+                $schema31 = new SchemaObject(
+                    type: 'string',
+                    nullable: true
+                );
+
+                $rules30 = $this->mapper->mapValidationRules($schema30, 'field');
+                $rules31 = $this->mapper->mapValidationRules($schema31, 'field');
+
+                expect($rules30['field'])->toBe($rules31['field']);
+                expect($rules30['field'])->toContain('nullable');
+                expect($rules30['field'])->toContain('string');
+            });
+
+            it('should maintain existing behavior for non-nullable fields', function (): void {
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'name' => new SchemaObject(type: 'string'),
+                        'email' => new SchemaObject(type: 'string', format: 'email'),
+                    ],
+                    required: ['name', 'email']
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema);
+
+                expect($rules['name'])->toContain('required');
+                expect($rules['name'])->toContain('string');
+                expect($rules['name'])->not->toContain('nullable');
+
+                expect($rules['email'])->toContain('required');
+                expect($rules['email'])->toContain('email');
+                expect($rules['email'])->not->toContain('nullable');
+            });
+        });
+
+        describe('complex scenarios with union types', function (): void {
+            it('should handle nested objects with nullable properties', function (): void {
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'user' => new SchemaObject(
+                            type: 'object',
+                            properties: [
+                                'name' => new SchemaObject(type: 'string'),
+                                'bio' => new SchemaObject(type: 'string', nullable: true),
+                                'settings' => new SchemaObject(
+                                    type: 'object',
+                                    properties: [
+                                        'theme' => new SchemaObject(type: 'string', nullable: true),
+                                    ]
+                                ),
+                            ],
+                            required: ['name']
+                        ),
+                    ],
+                    required: ['user']
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema);
+
+                expect($rules['user'])->toContain('required');
+                expect($rules['user.name'])->toContain('required');
+                expect($rules['user.bio'])->toContain('nullable');
+                expect($rules['user.settings'])->toContain('nullable');
+                expect($rules['user.settings.theme'])->toContain('nullable');
+            });
+
+            it('should handle arrays with nullable items', function (): void {
+                $schema = new SchemaObject(
+                    type: 'array',
+                    items: new SchemaObject(
+                        type: 'object',
+                        properties: [
+                            'id' => new SchemaObject(type: 'integer'),
+                            'description' => new SchemaObject(type: 'string', nullable: true),
+                        ],
+                        required: ['id']
+                    )
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema, 'items');
+
+                expect($rules['items'])->toContain('array');
+                expect($rules['items.*.id'])->toContain('required');
+                expect($rules['items.*.description'])->toContain('nullable');
+            });
+
+            it('should combine format rules with nullable', function (): void {
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'optional_email' => new SchemaObject(
+                            type: 'string',
+                            format: 'email',
+                            nullable: true
+                        ),
+                        'optional_date' => new SchemaObject(
+                            type: 'string',
+                            format: 'date',
+                            nullable: true
+                        ),
+                    ]
+                );
+
+                $rules = $this->mapper->mapValidationRules($schema);
+
+                expect($rules['optional_email'])->toContain('nullable');
+                expect($rules['optional_email'])->toContain('email');
+
+                expect($rules['optional_date'])->toContain('nullable');
+                expect($rules['optional_date'])->toContain('date_format:Y-m-d');
+            });
+        });
+
+        describe('validation rule generation with union types', function (): void {
+            it('should build rules with proper ordering for nullable fields', function (): void {
+                $schema = new SchemaObject(
+                    type: 'string',
+                    format: 'email',
+                    nullable: true,
+                    validation: new ValidationConstraints(
+                        minLength: 5,
+                        maxLength: 100
+                    )
+                );
+
+                $rule = $this->mapper->buildRule($schema, 'email');
+
+                expect($rule)->toContain('string');
+                expect($rule)->toContain('email');
+                expect($rule)->toContain('min:5');
+                expect($rule)->toContain('max:100');
+
+                // When used in context, nullable should come first
+                $rules = $this->mapper->mapValidationRules($schema, 'email');
+                expect($rules['email'])->toStartWith('nullable');
+            });
+
+            it('should handle createValidationRules with nullable types', function (): void {
+                $schema = new SchemaObject(
+                    type: 'object',
+                    properties: [
+                        'name' => new SchemaObject(type: 'string'),
+                        'bio' => new SchemaObject(type: 'string', nullable: true),
+                    ],
+                    required: ['name']
+                );
+
+                $rules = $this->mapper->createValidationRules($schema);
+
+                $nameRules = array_filter($rules, fn ($rule) => $rule->fieldPath === 'name');
+                $bioRules = array_filter($rules, fn ($rule) => $rule->fieldPath === 'bio');
+
+                expect($nameRules)->not->toBeEmpty();
+                expect($bioRules)->not->toBeEmpty();
+
+                $nameRequiredRules = array_filter($nameRules, fn ($rule) => in_array('required', $rule->rules));
+                $bioNullableRules = array_filter($bioRules, fn ($rule) => in_array('nullable', $rule->rules));
+
+                expect($nameRequiredRules)->not->toBeEmpty();
+                expect($bioNullableRules)->not->toBeEmpty();
+            });
+        });
+    });
 });

--- a/tests/unit/Generator/ValidationRuleMapperTest.php
+++ b/tests/unit/Generator/ValidationRuleMapperTest.php
@@ -706,11 +706,11 @@ describe('ValidationRuleMapper', function (): void {
                 $schema = new SchemaObject(
                     type: 'string',
                     format: 'email',
-                    nullable: true,
                     validation: new ValidationConstraints(
                         minLength: 5,
                         maxLength: 100
-                    )
+                    ),
+                    nullable: true
                 );
 
                 $rule = $this->mapper->buildRule($schema, 'email');
@@ -737,14 +737,14 @@ describe('ValidationRuleMapper', function (): void {
 
                 $rules = $this->mapper->createValidationRules($schema);
 
-                $nameRules = array_filter($rules, fn ($rule) => $rule->fieldPath === 'name');
-                $bioRules = array_filter($rules, fn ($rule) => $rule->fieldPath === 'bio');
+                $nameRules = array_filter($rules, fn ($rule): bool => $rule->fieldPath === 'name');
+                $bioRules = array_filter($rules, fn ($rule): bool => $rule->fieldPath === 'bio');
 
                 expect($nameRules)->not->toBeEmpty();
                 expect($bioRules)->not->toBeEmpty();
 
-                $nameRequiredRules = array_filter($nameRules, fn ($rule) => in_array('required', $rule->rules));
-                $bioNullableRules = array_filter($bioRules, fn ($rule) => in_array('nullable', $rule->rules));
+                $nameRequiredRules = array_filter($nameRules, fn ($rule): bool => in_array('required', $rule->rules));
+                $bioNullableRules = array_filter($bioRules, fn ($rule): bool => in_array('nullable', $rule->rules));
 
                 expect($nameRequiredRules)->not->toBeEmpty();
                 expect($bioNullableRules)->not->toBeEmpty();

--- a/tests/unit/Models/ValidationConstraintsTest.php
+++ b/tests/unit/Models/ValidationConstraintsTest.php
@@ -30,6 +30,20 @@ describe('ValidationConstraints', function (): void {
             expect($constraints->multipleOf)->toBe(5);
         });
 
+        it('should create constraints with exclusive numeric validation', function (): void {
+            $constraints = new ValidationConstraints(
+                exclusiveMinimum: 0,
+                exclusiveMaximum: 100,
+                minimum: 5,
+                maximum: 95
+            );
+
+            expect($constraints->exclusiveMinimum)->toBe(0);
+            expect($constraints->exclusiveMaximum)->toBe(100);
+            expect($constraints->minimum)->toBe(5);
+            expect($constraints->maximum)->toBe(95);
+        });
+
         it('should create constraints with array validation', function (): void {
             $constraints = new ValidationConstraints(
                 minItems: 1,
@@ -51,6 +65,8 @@ describe('ValidationConstraints', function (): void {
             expect($constraints->enum)->toBeNull();
             expect($constraints->minimum)->toBeNull();
             expect($constraints->maximum)->toBeNull();
+            expect($constraints->exclusiveMinimum)->toBeNull();
+            expect($constraints->exclusiveMaximum)->toBeNull();
             expect($constraints->multipleOf)->toBeNull();
             expect($constraints->minItems)->toBeNull();
             expect($constraints->maxItems)->toBeNull();
@@ -100,6 +116,20 @@ describe('ValidationConstraints', function (): void {
             );
 
             expect($constraints->hasNumericConstraints())->toBeTrue();
+        });
+
+        it('should return true when exclusive bounds exist', function (): void {
+            $constraints = new ValidationConstraints(
+                exclusiveMinimum: 0
+            );
+
+            expect($constraints->hasNumericConstraints())->toBeTrue();
+
+            $constraints2 = new ValidationConstraints(
+                exclusiveMaximum: 100
+            );
+
+            expect($constraints2->hasNumericConstraints())->toBeTrue();
         });
 
         it('should return false when no numeric constraints exist', function (): void {
@@ -376,6 +406,124 @@ describe('ValidationConstraints', function (): void {
             $constraints = new ValidationConstraints;
 
             expect($constraints->getComplexityScore())->toBe(0);
+        });
+    });
+
+    describe('getNumericValidationRules', function (): void {
+        it('should generate gt rule for exclusiveMinimum', function (): void {
+            $constraints = new ValidationConstraints(
+                exclusiveMinimum: 0
+            );
+
+            $rules = $constraints->getNumericValidationRules();
+
+            expect($rules)->toContain('gt:0');
+        });
+
+        it('should generate lt rule for exclusiveMaximum', function (): void {
+            $constraints = new ValidationConstraints(
+                exclusiveMaximum: 100
+            );
+
+            $rules = $constraints->getNumericValidationRules();
+
+            expect($rules)->toContain('lt:100');
+        });
+
+        it('should prefer exclusive bounds over inclusive bounds', function (): void {
+            $constraints = new ValidationConstraints(
+                minimum: 5,
+                maximum: 95,
+                exclusiveMinimum: 0,
+                exclusiveMaximum: 100
+            );
+
+            $rules = $constraints->getNumericValidationRules();
+
+            expect($rules)->toContain('gt:0');
+            expect($rules)->toContain('lt:100');
+            expect($rules)->not->toContain('min:5');
+            expect($rules)->not->toContain('max:95');
+        });
+
+        it('should use inclusive bounds when no exclusive bounds exist', function (): void {
+            $constraints = new ValidationConstraints(
+                minimum: 5,
+                maximum: 95
+            );
+
+            $rules = $constraints->getNumericValidationRules();
+
+            expect($rules)->toContain('min:5');
+            expect($rules)->toContain('max:95');
+        });
+    });
+
+    describe('fromSchema', function (): void {
+        it('should parse OpenAPI 3.1 numeric exclusiveMinimum/exclusiveMaximum', function (): void {
+            $schema = [
+                'type' => 'number',
+                'exclusiveMinimum' => 0,
+                'exclusiveMaximum' => 100,
+                'minimum' => 5,
+                'maximum' => 95,
+            ];
+
+            $constraints = ValidationConstraints::fromSchema($schema);
+
+            expect($constraints->exclusiveMinimum)->toBe(0);
+            expect($constraints->exclusiveMaximum)->toBe(100);
+            expect($constraints->minimum)->toBe(5);
+            expect($constraints->maximum)->toBe(95);
+        });
+
+        it('should handle OpenAPI 3.0 boolean exclusiveMinimum/exclusiveMaximum', function (): void {
+            $schema = [
+                'type' => 'number',
+                'minimum' => 0,
+                'maximum' => 100,
+                'exclusiveMinimum' => true,
+                'exclusiveMaximum' => true,
+            ];
+
+            $constraints = ValidationConstraints::fromSchema($schema);
+
+            expect($constraints->exclusiveMinimum)->toBe(0);
+            expect($constraints->exclusiveMaximum)->toBe(100);
+            expect($constraints->minimum)->toBe(0);
+            expect($constraints->maximum)->toBe(100);
+        });
+
+        it('should ignore OpenAPI 3.0 false exclusiveMinimum/exclusiveMaximum', function (): void {
+            $schema = [
+                'type' => 'number',
+                'minimum' => 0,
+                'maximum' => 100,
+                'exclusiveMinimum' => false,
+                'exclusiveMaximum' => false,
+            ];
+
+            $constraints = ValidationConstraints::fromSchema($schema);
+
+            expect($constraints->exclusiveMinimum)->toBeNull();
+            expect($constraints->exclusiveMaximum)->toBeNull();
+            expect($constraints->minimum)->toBe(0);
+            expect($constraints->maximum)->toBe(100);
+        });
+
+        it('should handle mixed OpenAPI 3.1 numeric and 3.0 boolean syntax', function (): void {
+            $schema = [
+                'type' => 'number',
+                'minimum' => 5,
+                'exclusiveMaximum' => 100, // Numeric (3.1)
+                'exclusiveMinimum' => true, // Boolean (3.0) - should use minimum value
+            ];
+
+            $constraints = ValidationConstraints::fromSchema($schema);
+
+            expect($constraints->exclusiveMinimum)->toBe(5); // From minimum when exclusiveMinimum=true
+            expect($constraints->exclusiveMaximum)->toBe(100); // Numeric value
+            expect($constraints->minimum)->toBe(5);
         });
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full OpenAPI 3.1 union-type support with null handling; schema objects expose nullability and primary-type accessors.
  * Added exclusiveMinimum/exclusiveMaximum support, generating gt/lt rules and taking precedence over inclusive bounds.
  * Consistent required/nullable rule prefixing across scalars, arrays, and nested properties.

* **Tests**
  * Expanded tests for union nullability, exclusive numeric bounds, and OpenAPI 3.0/3.1 backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->