### PR TITLE
Added support for setting basepath. Added support for automatic basepath detection from openapi servers array.

### DIFF
--- a/src/Console/ValidateRoutesCommand.php
+++ b/src/Console/ValidateRoutesCommand.php
@@ -25,6 +25,7 @@ class ValidateRoutesCommand extends Command
      */
     protected $signature = 'openapi-to-laravel:validate-routes
                             {spec : Path to OpenAPI specification file}
+                            {--base-path= : Override server base path (e.g., /api)}
                             {--include-pattern=* : Route URI patterns to include (supports wildcards)}
                             {--exclude-middleware=* : Middleware groups to exclude}
                             {--ignore-route=* : Route names/patterns to ignore}
@@ -46,6 +47,8 @@ class ValidateRoutesCommand extends Command
         $specPathValue = $this->argument('spec');
         $specPath = is_string($specPathValue) ? $specPathValue : '';
 
+        /** @var string|null $basePath */
+        $basePath = is_string($this->option('base-path')) ? $this->option('base-path') : null;
         /** @var array<string> $includePatterns */
         $includePatterns = is_array($this->option('include-pattern')) ? $this->option('include-pattern') : [];
         /** @var array<string> $excludeMiddleware */
@@ -71,6 +74,10 @@ class ValidateRoutesCommand extends Command
             $this->info('Starting route validation...');
             $this->info("OpenAPI spec: {$specPath}");
 
+            if ($basePath !== null) {
+                $this->info("Base path override: {$basePath}");
+            }
+
             if (! empty($includePatterns)) {
                 $this->info('Include patterns: ' . implode(', ', $includePatterns));
             }
@@ -89,6 +96,7 @@ class ValidateRoutesCommand extends Command
 
             // Prepare validation options
             $options = [
+                'base_path' => $basePath,
                 'include_patterns' => $includePatterns,
                 'exclude_middleware' => $excludeMiddleware,
                 'ignore_routes' => $ignoreRoutes,

--- a/src/Models/EndpointDefinition.php
+++ b/src/Models/EndpointDefinition.php
@@ -239,7 +239,10 @@ class EndpointDefinition
 
         $operationId = strtolower($method);
         foreach ($parts as $part) {
-            $operationId .= ucfirst(strtolower($part));
+            // Handle hyphens and underscores in path segments
+            $part = preg_replace('/[_\-]/', ' ', $part) ?? $part;
+            $part = ucwords(strtolower($part));
+            $operationId .= str_replace(' ', '', $part);
         }
 
         return $operationId;

--- a/src/Models/OpenApiSpecification.php
+++ b/src/Models/OpenApiSpecification.php
@@ -16,7 +16,7 @@ class OpenApiSpecification
         public readonly array $paths,
         /** @var array<string, mixed> */
         public readonly array $components = [],
-        /** @var array<string, mixed> */
+        /** @var array<int, array<string, mixed>> */
         public readonly array $servers = []
     ) {
         // Minimal validation in constructor to allow test scenarios
@@ -36,7 +36,7 @@ class OpenApiSpecification
             info: self::validateArray($spec['info'] ?? []),
             paths: self::validateArray($spec['paths'] ?? []),
             components: self::validateArray($spec['components'] ?? []),
-            servers: self::validateArray($spec['servers'] ?? [])
+            servers: self::validateServersArray($spec['servers'] ?? [])
         );
     }
 
@@ -214,6 +214,28 @@ class OpenApiSpecification
     {
         if (is_array($value)) {
             return $value;
+        }
+
+        return [];
+    }
+
+    /**
+     * Validate and cast servers array
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private static function validateServersArray(mixed $value): array
+    {
+        if (is_array($value)) {
+            // Ensure all elements are arrays and reindex
+            $servers = [];
+            foreach ($value as $server) {
+                if (is_array($server)) {
+                    $servers[] = $server;
+                }
+            }
+
+            return $servers;
         }
 
         return [];

--- a/src/Parser/ServerPathExtractor.php
+++ b/src/Parser/ServerPathExtractor.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Maan511\OpenapiToLaravel\Parser;
+
+use InvalidArgumentException;
+use Maan511\OpenapiToLaravel\Models\OpenApiSpecification;
+
+class ServerPathExtractor
+{
+    /**
+     * Extract base paths from all servers in the specification
+     *
+     * @return array<string>
+     */
+    public function extractBasePaths(OpenApiSpecification $specification): array
+    {
+        $basePaths = [];
+
+        foreach ($specification->servers as $server) {
+            if (! isset($server['url']) || ! is_string($server['url'])) {
+                continue;
+            }
+
+            $basePath = $this->extractBasePathFromUrl($server['url']);
+            if ($basePath !== '' && ! in_array($basePath, $basePaths)) {
+                $basePaths[] = $basePath;
+            }
+        }
+
+        return $basePaths;
+    }
+
+    /**
+     * Get the default base path (first server's path, or empty if none)
+     */
+    public function getDefaultBasePath(OpenApiSpecification $specification): string
+    {
+        $basePaths = $this->extractBasePaths($specification);
+
+        return $basePaths[0] ?? '';
+    }
+
+    /**
+     * Validate and resolve base path based on specification and user choice
+     */
+    public function resolveBasePath(OpenApiSpecification $specification, ?string $userBasePath = null): string
+    {
+        $availablePaths = $this->extractBasePaths($specification);
+
+        // If user specified a base path, validate it
+        if ($userBasePath !== null) {
+            $userBasePath = $this->normalizeBasePath($userBasePath);
+
+            if (! in_array($userBasePath, $availablePaths) && $availablePaths !== []) {
+                throw new InvalidArgumentException(
+                    "Specified base path '{$userBasePath}' not found in servers. Available paths: " .
+                    implode(', ', $availablePaths)
+                );
+            }
+
+            return $userBasePath;
+        }
+
+        // If multiple paths available, require user to choose
+        if (count($availablePaths) > 1) {
+            throw new InvalidArgumentException(
+                'Multiple server base paths found: ' . implode(', ', $availablePaths) .
+                '. Please specify which one to use with --base-path option.'
+            );
+        }
+
+        // Return default (first path or empty)
+        return $this->getDefaultBasePath($specification);
+    }
+
+    /**
+     * Extract base path from a server URL
+     */
+    private function extractBasePathFromUrl(string $url): string
+    {
+        $parsedUrl = parse_url($url);
+
+        if ($parsedUrl === false) {
+            return '';
+        }
+
+        // Ensure URL has a valid scheme to be considered a proper server URL
+        if (! isset($parsedUrl['scheme']) || ! in_array($parsedUrl['scheme'], ['http', 'https'])) {
+            return '';
+        }
+
+        $path = $parsedUrl['path'] ?? '';
+
+        return $this->normalizeBasePath($path);
+    }
+
+    /**
+     * Normalize base path (ensure it starts with / and doesn't end with /)
+     */
+    private function normalizeBasePath(string $path): string
+    {
+        $path = trim($path);
+
+        if ($path === '' || $path === '/') {
+            return '';
+        }
+
+        // Ensure starts with /
+        if (! str_starts_with($path, '/')) {
+            $path = '/' . $path;
+        }
+
+        // Remove trailing /
+        return rtrim($path, '/');
+    }
+}

--- a/src/Parser/ServerPathExtractor.php
+++ b/src/Parser/ServerPathExtractor.php
@@ -17,10 +17,12 @@ class ServerPathExtractor
         $basePaths = [];
 
         foreach ($specification->servers as $server) {
-            if (! isset($server['url']) || ! is_string($server['url'])) {
+            if (! isset($server['url'])) {
                 continue;
             }
-
+            if (! is_string($server['url'])) {
+                continue;
+            }
             $basePath = $this->extractBasePathFromUrl($server['url']);
             if ($basePath !== '' && ! in_array($basePath, $basePaths)) {
                 $basePaths[] = $basePath;
@@ -84,8 +86,8 @@ class ServerPathExtractor
             return '';
         }
 
-        // Ensure URL has a valid scheme to be considered a proper server URL
-        if (! isset($parsedUrl['scheme']) || ! in_array($parsedUrl['scheme'], ['http', 'https'])) {
+        // Only reject URLs with invalid schemes; allow relative URLs without schemes
+        if (isset($parsedUrl['scheme']) && ! in_array($parsedUrl['scheme'], ['http', 'https'])) {
             return '';
         }
 

--- a/src/Validation/RouteValidator.php
+++ b/src/Validation/RouteValidator.php
@@ -8,6 +8,7 @@ use Maan511\OpenapiToLaravel\Models\LaravelRoute;
 use Maan511\OpenapiToLaravel\Models\RouteMismatch;
 use Maan511\OpenapiToLaravel\Models\ValidationResult;
 use Maan511\OpenapiToLaravel\Parser\OpenApiParser;
+use Maan511\OpenapiToLaravel\Parser\ServerPathExtractor;
 
 /**
  * Main orchestrator for route validation
@@ -16,7 +17,8 @@ class RouteValidator
 {
     public function __construct(
         private readonly LaravelRouteCollector $routeCollector,
-        private readonly OpenApiParser $openApiParser
+        private readonly OpenApiParser $openApiParser,
+        private readonly ServerPathExtractor $serverPathExtractor = new ServerPathExtractor
     ) {}
 
     /**
@@ -29,7 +31,14 @@ class RouteValidator
         try {
             // Parse OpenAPI specification
             $specification = $this->openApiParser->parseFromFile($specPath);
-            $endpoints = $this->openApiParser->extractEndpoints($specification);
+
+            // Resolve base path from servers or user specification
+            $basePath = $this->serverPathExtractor->resolveBasePath(
+                $specification,
+                $options['base_path'] ?? null
+            );
+
+            $endpoints = $this->openApiParser->extractEndpoints($specification, $basePath);
 
             // Collect Laravel routes
             $laravelRoutes = $this->routeCollector->collect($options);

--- a/src/Validation/RouteValidator.php
+++ b/src/Validation/RouteValidator.php
@@ -15,11 +15,15 @@ use Maan511\OpenapiToLaravel\Parser\ServerPathExtractor;
  */
 class RouteValidator
 {
+    private readonly ServerPathExtractor $serverPathExtractor;
+
     public function __construct(
         private readonly LaravelRouteCollector $routeCollector,
         private readonly OpenApiParser $openApiParser,
-        private readonly ServerPathExtractor $serverPathExtractor = new ServerPathExtractor
-    ) {}
+        ?ServerPathExtractor $serverPathExtractor = null
+    ) {
+        $this->serverPathExtractor = $serverPathExtractor ?? new ServerPathExtractor;
+    }
 
     /**
      * Validate routes against OpenAPI specification

--- a/tests/unit/Models/EndpointDefinitionTest.php
+++ b/tests/unit/Models/EndpointDefinitionTest.php
@@ -130,6 +130,30 @@ describe('EndpointDefinition', function (): void {
             expect($endpoint->operationId)->toBe('getUsersId');
         });
 
+        it('should generate operation ID handling hyphens in path segments', function (): void {
+            $operation = [];
+
+            $endpoint = EndpointDefinition::fromOperation(
+                '/close-days',
+                'get',
+                $operation
+            );
+
+            expect($endpoint->operationId)->toBe('getCloseDays');
+        });
+
+        it('should generate operation ID handling underscores and hyphens in path segments', function (): void {
+            $operation = [];
+
+            $endpoint = EndpointDefinition::fromOperation(
+                '/user-profiles/detailed_info/{id}',
+                'post',
+                $operation
+            );
+
+            expect($endpoint->operationId)->toBe('postUserProfilesDetailedInfoId');
+        });
+
         it('should handle malformed operation data gracefully', function (): void {
             $operation = [
                 'summary' => 123, // Invalid type

--- a/tests/unit/Parser/ServerPathExtractorTest.php
+++ b/tests/unit/Parser/ServerPathExtractorTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use Maan511\OpenapiToLaravel\Models\OpenApiSpecification;
+use Maan511\OpenapiToLaravel\Parser\ServerPathExtractor;
+
+describe('ServerPathExtractor', function (): void {
+    it('should extract base paths from servers', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api/v1'],
+                ['url' => 'https://staging.example.com/api'],
+                ['url' => 'http://localhost:8000'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $basePaths = $extractor->extractBasePaths($specification);
+
+        expect($basePaths)->toBe(['/api/v1', '/api']);
+    });
+
+    it('should return empty array when no servers have paths', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com'],
+                ['url' => 'http://localhost:8000/'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $basePaths = $extractor->extractBasePaths($specification);
+
+        expect($basePaths)->toBe([]);
+    });
+
+    it('should get default base path from first server', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api'],
+                ['url' => 'https://staging.example.com/v2'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $defaultPath = $extractor->getDefaultBasePath($specification);
+
+        expect($defaultPath)->toBe('/api');
+    });
+
+    it('should return empty string when no servers', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: []
+        );
+
+        $extractor = new ServerPathExtractor;
+        $defaultPath = $extractor->getDefaultBasePath($specification);
+
+        expect($defaultPath)->toBe('');
+    });
+
+    it('should resolve base path with user override', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api'],
+                ['url' => 'https://staging.example.com/v2'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $resolvedPath = $extractor->resolveBasePath($specification, '/v2');
+
+        expect($resolvedPath)->toBe('/v2');
+    });
+
+    it('should throw exception when user specifies invalid base path', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+
+        expect(fn () => $extractor->resolveBasePath($specification, '/invalid'))
+            ->toThrow(InvalidArgumentException::class, 'Specified base path \'/invalid\' not found in servers');
+    });
+
+    it('should throw exception when multiple base paths available and none specified', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api'],
+                ['url' => 'https://staging.example.com/v2'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+
+        expect(fn () => $extractor->resolveBasePath($specification))
+            ->toThrow(InvalidArgumentException::class, 'Multiple server base paths found');
+    });
+
+    it('should normalize base paths correctly', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'https://api.example.com/api/'],
+                ['url' => 'https://staging.example.com/v2//'],
+                ['url' => 'http://localhost:8000/'],
+                ['url' => 'http://localhost:3000'],
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $basePaths = $extractor->extractBasePaths($specification);
+
+        expect($basePaths)->toBe(['/api', '/v2']);
+    });
+
+    it('should handle malformed server URLs gracefully', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [
+                ['url' => 'not-a-valid-url'],
+                ['url' => 'https://api.example.com/api'],
+                [], // Missing url
+                ['url' => 123], // Non-string url
+            ]
+        );
+
+        $extractor = new ServerPathExtractor;
+        $basePaths = $extractor->extractBasePaths($specification);
+
+        expect($basePaths)->toBe(['/api']);
+    });
+
+    it('should allow user to specify custom base path even when not in servers', function (): void {
+        $specification = new OpenApiSpecification(
+            filePath: 'test.json',
+            version: '3.0.0',
+            info: ['title' => 'Test API', 'version' => '1.0.0'],
+            paths: [],
+            servers: [] // No servers
+        );
+
+        $extractor = new ServerPathExtractor;
+        $resolvedPath = $extractor->resolveBasePath($specification, '/custom');
+
+        expect($resolvedPath)->toBe('/custom');
+    });
+});

--- a/tests/unit/Parser/ServerPathExtractorTest.php
+++ b/tests/unit/Parser/ServerPathExtractorTest.php
@@ -105,7 +105,7 @@ describe('ServerPathExtractor', function (): void {
 
         $extractor = new ServerPathExtractor;
 
-        expect(fn () => $extractor->resolveBasePath($specification, '/invalid'))
+        expect(fn (): string => $extractor->resolveBasePath($specification, '/invalid'))
             ->toThrow(InvalidArgumentException::class, 'Specified base path \'/invalid\' not found in servers');
     });
 
@@ -123,7 +123,7 @@ describe('ServerPathExtractor', function (): void {
 
         $extractor = new ServerPathExtractor;
 
-        expect(fn () => $extractor->resolveBasePath($specification))
+        expect(fn (): string => $extractor->resolveBasePath($specification))
             ->toThrow(InvalidArgumentException::class, 'Multiple server base paths found');
     });
 
@@ -164,7 +164,7 @@ describe('ServerPathExtractor', function (): void {
         $extractor = new ServerPathExtractor;
         $basePaths = $extractor->extractBasePaths($specification);
 
-        expect($basePaths)->toBe(['/api']);
+        expect($basePaths)->toBe(['/not-a-valid-url', '/api']);
     });
 
     it('should allow user to specify custom base path even when not in servers', function (): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added --base-path option to override server base path in route validation.
  - Automatic base-path detection and resolution from OpenAPI servers when not provided.
  - Parser now prefixes endpoints with resolved base path and skips non-HTTP path entries.

- Improvements
  - More consistent operationId generation for path segments with hyphens/underscores.
  - Normalized servers handling in specification parsing.

- Tests
  - Added unit tests for base-path extraction/resolution and operationId generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->