### PR TITLE
Changed default ouput format to table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,7 @@ php artisan openapi-to-laravel:validate-routes spec.json --report-format=console
 - `--include-pattern=PATTERN`: Route URI patterns to include (supports wildcards, can be used multiple times)
 - `--exclude-middleware=MIDDLEWARE`: Middleware groups to exclude from validation (can be used multiple times)
 - `--ignore-route=PATTERN`: Route names/patterns to ignore (supports wildcards, can be used multiple times)
-- `--report-format=FORMAT`: Report format(s): console, json, html, table (default: console)
+- `--report-format=FORMAT`: Report format(s): console, json, html, table (default: table)
 - `--output-file=FILE`: Save report to file (extension determined by format)
 - `--strict`: Fail command execution on any mismatches (useful for CI/CD)
 - `--suggestions`: Include actionable fix suggestions in output

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ php artisan openapi-to-laravel:validate-routes path/to/your/openapi.json
 
 **Common options:**
 - `--strict` - Fail on any mismatches (perfect for CI/CD)
-- `--report-format=console,json,html` - Choose output format
+- `--report-format=console,json,html,table` - Choose output format (default: table)
 - `--include-pattern="api/*"` - Only validate specific routes
 
 **Next Steps:** Use your generated FormRequest classes in your Laravel controllers for automatic validation and run route validation in your CI/CD pipeline.

--- a/src/Console/ValidateRoutesCommand.php
+++ b/src/Console/ValidateRoutesCommand.php
@@ -32,7 +32,7 @@ class ValidateRoutesCommand extends Command
                             {--include-pattern=* : Route URI patterns to include (supports wildcards)}
                             {--exclude-middleware=* : Middleware groups to exclude}
                             {--ignore-route=* : Route names/patterns to ignore}
-                            {--report-format=console : Report format (console, json, html, table)}
+                            {--report-format=table : Report format (console, json, html, table)}
                             {--output-file= : Save report to file}
                             {--strict : Fail command on any mismatches}
                             {--suggestions : Include fix suggestions in output}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * validate-routes now defaults to table output when --report-format is not specified (still supports console, json, html, table).

* **Documentation**
  * Updated README to reflect the new default table format and list available report formats.
  * Clarified command usage examples to show table as the default output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->