### PR TITLE
feat: display all routes in validation table when no filter applied

### DIFF
--- a/src/Console/ValidateRoutesCommand.php
+++ b/src/Console/ValidateRoutesCommand.php
@@ -250,6 +250,119 @@ class ValidateRoutesCommand extends Command
      */
     private function buildTableData(ValidationResult $result): array
     {
+        // If we have all routes/endpoints data (no filter applied), show everything
+        if ($result->allRoutes !== null && $result->allEndpoints !== null) {
+            return $this->buildCompleteTableData($result);
+        }
+
+        // Fallback to mismatch-only data (filtered results)
+        return $this->buildMismatchTableData($result);
+    }
+
+    /**
+     * Build table data showing all routes and endpoints (when no filter is applied)
+     *
+     * @return array<array<string>>
+     */
+    private function buildCompleteTableData(ValidationResult $result): array
+    {
+        $rows = [];
+        $processedSignatures = [];
+
+        // Create mismatch lookup for quick status determination
+        $mismatchMap = [];
+        foreach ($result->mismatches as $mismatch) {
+            $signature = $mismatch->method . ':' . $mismatch->path;
+            $mismatchMap[$signature] = $mismatch;
+        }
+
+        // Process all routes
+        if ($result->allRoutes !== null) {
+            foreach ($result->allRoutes as $route) {
+                foreach ($route->methods as $method) {
+                    $signature = $method . ':' . $route->getNormalizedPath();
+                    if (isset($processedSignatures[$signature])) {
+                        continue;
+                    }
+                    $processedSignatures[$signature] = true;
+
+                    $status = isset($mismatchMap[$signature])
+                        ? $this->getStatusFromMismatch($mismatchMap[$signature])
+                        : '✓ Match';
+
+                    $rows[] = [
+                        $method,
+                        $route->getNormalizedPath(),
+                        $this->formatParameters($route->pathParameters),
+                        '', // Will be filled if matching endpoint exists
+                        'Laravel',
+                        $status,
+                    ];
+                }
+            }
+        }
+
+        // Process all endpoints and update existing rows or add new ones
+        if ($result->allEndpoints !== null) {
+            foreach ($result->allEndpoints as $endpoint) {
+                $signature = $endpoint->method . ':' . $endpoint->path;
+
+                // Find existing row for this signature
+                $rowIndex = null;
+                foreach ($rows as $index => $row) {
+                    if ($row[0] === $endpoint->method && $row[1] === $endpoint->path) {
+                        $rowIndex = $index;
+                        break;
+                    }
+                }
+
+                if ($rowIndex !== null) {
+                    // Update existing row with endpoint parameters and source
+                    $rows[$rowIndex][3] = $this->formatParameters($this->extractPathParameters($endpoint->path));
+                    $rows[$rowIndex][4] = 'Both';
+                } else {
+                    // Add new row for endpoint-only item
+                    if (isset($processedSignatures[$signature])) {
+                        continue;
+                    }
+                    $processedSignatures[$signature] = true;
+
+                    $status = isset($mismatchMap[$signature])
+                        ? $this->getStatusFromMismatch($mismatchMap[$signature])
+                        : '✓ Match';
+
+                    $rows[] = [
+                        $endpoint->method,
+                        $endpoint->path,
+                        '', // No Laravel parameters
+                        $this->formatParameters($this->extractPathParameters($endpoint->path)),
+                        'OpenAPI',
+                        $status,
+                    ];
+                }
+            }
+        }
+
+        // Sort rows by method and path
+        usort($rows, function (array $a, array $b): int {
+            $pathCompare = strcmp($a[1], $b[1]);
+            if ($pathCompare !== 0) {
+                return $pathCompare;
+            }
+
+            return strcmp($a[0], $b[0]);
+        });
+
+        return $rows;
+    }
+
+    /**
+     * Build table data from mismatches only (filtered results)
+     *
+     * @return array<array<string>>
+     */
+    private function buildMismatchTableData(ValidationResult $result): array
+    {
         $rows = [];
         $routeMap = $this->buildRouteMap($result);
         $endpointMap = $this->buildEndpointMap($result);
@@ -281,6 +394,20 @@ class ValidateRoutesCommand extends Command
         }
 
         return $rows;
+    }
+
+    /**
+     * Get status from mismatch object
+     */
+    private function getStatusFromMismatch(RouteMismatch $mismatch): string
+    {
+        return match ($mismatch->type) {
+            RouteMismatch::TYPE_MISSING_DOCUMENTATION => '✗ Missing Doc',
+            RouteMismatch::TYPE_MISSING_IMPLEMENTATION => '✗ Missing Impl',
+            RouteMismatch::TYPE_METHOD_MISMATCH => '⚠ Method Mismatch',
+            RouteMismatch::TYPE_PARAMETER_MISMATCH => '⚠ Param Mismatch',
+            default => '⚠ Other Issue',
+        };
     }
 
     /**

--- a/src/Models/ValidationResult.php
+++ b/src/Models/ValidationResult.php
@@ -11,24 +11,32 @@ class ValidationResult
      * @param  array<RouteMismatch>  $mismatches
      * @param  array<string>  $warnings
      * @param  array<string, mixed>  $statistics
+     * @param  array<\Maan511\OpenapiToLaravel\Models\LaravelRoute>|null  $allRoutes  All routes when no filter is applied
+     * @param  array<\Maan511\OpenapiToLaravel\Models\EndpointDefinition>|null  $allEndpoints  All endpoints when no filter is applied
      */
     public function __construct(
         public readonly bool $isValid,
         public readonly array $mismatches = [],
         public readonly array $warnings = [],
-        public readonly array $statistics = []
+        public readonly array $statistics = [],
+        public readonly ?array $allRoutes = null,
+        public readonly ?array $allEndpoints = null
     ) {}
 
     /**
      * Create a successful validation result
      *
      * @param  array<string, mixed>  $statistics
+     * @param  array<\Maan511\OpenapiToLaravel\Models\LaravelRoute>|null  $allRoutes
+     * @param  array<\Maan511\OpenapiToLaravel\Models\EndpointDefinition>|null  $allEndpoints
      */
-    public static function success(array $statistics = []): self
+    public static function success(array $statistics = [], ?array $allRoutes = null, ?array $allEndpoints = null): self
     {
         return new self(
             isValid: true,
-            statistics: $statistics
+            statistics: $statistics,
+            allRoutes: $allRoutes,
+            allEndpoints: $allEndpoints
         );
     }
 
@@ -38,14 +46,18 @@ class ValidationResult
      * @param  array<RouteMismatch>  $mismatches
      * @param  array<string>  $warnings
      * @param  array<string, mixed>  $statistics
+     * @param  array<\Maan511\OpenapiToLaravel\Models\LaravelRoute>|null  $allRoutes
+     * @param  array<\Maan511\OpenapiToLaravel\Models\EndpointDefinition>|null  $allEndpoints
      */
-    public static function failed(array $mismatches, array $warnings = [], array $statistics = []): self
+    public static function failed(array $mismatches, array $warnings = [], array $statistics = [], ?array $allRoutes = null, ?array $allEndpoints = null): self
     {
         return new self(
             isValid: false,
             mismatches: $mismatches,
             warnings: $warnings,
-            statistics: $statistics
+            statistics: $statistics,
+            allRoutes: $allRoutes,
+            allEndpoints: $allEndpoints
         );
     }
 
@@ -137,7 +149,9 @@ class ValidationResult
             isValid: $this->isValid && $other->isValid,
             mismatches: array_merge($this->mismatches, $other->mismatches),
             warnings: array_merge($this->warnings, $other->warnings),
-            statistics: array_merge($this->statistics, $other->statistics)
+            statistics: array_merge($this->statistics, $other->statistics),
+            allRoutes: $this->allRoutes ?? $other->allRoutes,
+            allEndpoints: $this->allEndpoints ?? $other->allEndpoints
         );
     }
 }

--- a/src/Validation/RouteValidator.php
+++ b/src/Validation/RouteValidator.php
@@ -129,11 +129,17 @@ class RouteValidator
         // Generate statistics
         $statistics = $this->generateStatistics($laravelRoutes, $endpoints, $mismatches, ! empty($options['filter_types']));
 
+        // Include all routes and endpoints when no filter is applied (for table display)
+        $allRoutes = empty($options['filter_types']) ? $laravelRoutes : null;
+        $allEndpoints = empty($options['filter_types']) ? $endpoints : null;
+
         return new ValidationResult(
             isValid: $mismatches === [],
             mismatches: $mismatches,
             warnings: $warnings,
-            statistics: $statistics
+            statistics: $statistics,
+            allRoutes: $allRoutes,
+            allEndpoints: $allEndpoints
         );
     }
 

--- a/tests/unit/Console/ValidateRoutesCommandAllRoutesTest.php
+++ b/tests/unit/Console/ValidateRoutesCommandAllRoutesTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use Maan511\OpenapiToLaravel\Console\ValidateRoutesCommand;
+use Maan511\OpenapiToLaravel\Models\EndpointDefinition;
+use Maan511\OpenapiToLaravel\Models\LaravelRoute;
+use Maan511\OpenapiToLaravel\Models\RouteMismatch;
+use Maan511\OpenapiToLaravel\Models\ValidationResult;
+
+describe('ValidateRoutesCommand All Routes Display', function (): void {
+    beforeEach(function (): void {
+        $this->validateCommand = new ValidateRoutesCommand;
+    });
+
+    it('should display all routes and endpoints when no filter is applied', function (): void {
+        // Create test routes and endpoints
+        $successfulRoute = new LaravelRoute(
+            uri: 'api/users',
+            methods: ['GET'],
+            name: 'users.index',
+            action: 'App\Http\Controllers\UserController@index',
+            middleware: ['api']
+        );
+
+        $missingDocRoute = new LaravelRoute(
+            uri: 'api/posts',
+            methods: ['POST'],
+            name: 'posts.store',
+            action: 'App\Http\Controllers\PostController@store',
+            middleware: ['api']
+        );
+
+        $successfulEndpoint = new EndpointDefinition(
+            path: '/api/users',
+            method: 'GET',
+            operationId: 'getUsers'
+        );
+
+        $missingImplEndpoint = new EndpointDefinition(
+            path: '/api/comments',
+            method: 'GET',
+            operationId: 'getComments'
+        );
+
+        // Create validation result with all routes/endpoints (no filter applied)
+        $validationResult = new ValidationResult(
+            isValid: false,
+            mismatches: [
+                RouteMismatch::missingDocumentation($missingDocRoute),
+                RouteMismatch::missingImplementation($missingImplEndpoint),
+            ],
+            warnings: [],
+            statistics: [
+                'total_routes' => 2,
+                'total_endpoints' => 2,
+                'covered_routes' => 1,
+                'covered_endpoints' => 1,
+            ],
+            allRoutes: [$successfulRoute, $missingDocRoute],
+            allEndpoints: [$successfulEndpoint, $missingImplEndpoint]
+        );
+
+        // Use reflection to access private method
+        $reflection = new ReflectionClass($this->validateCommand);
+        $buildTableDataMethod = $reflection->getMethod('buildTableData');
+
+        $tableData = $buildTableDataMethod->invoke($this->validateCommand, $validationResult);
+
+        // Should have 3 rows: 1 successful match + 2 mismatches
+        expect($tableData)->toHaveCount(3);
+
+        // Check that all items are present
+        $signatures = array_map(fn (array $row): string => $row[0] . ':' . $row[1], $tableData);
+
+        expect($signatures)->toContain('GET:/api/users')      // Successful match
+            ->and($signatures)->toContain('POST:/api/posts')   // Missing doc
+            ->and($signatures)->toContain('GET:/api/comments'); // Missing impl
+
+        // Check status indicators
+        $statuses = array_column($tableData, 5);
+        expect($statuses)->toContain('✓ Match')               // Successful route
+            ->and($statuses)->toContain('✗ Missing Doc')      // Missing documentation
+            ->and($statuses)->toContain('✗ Missing Impl');    // Missing implementation
+    });
+
+    it('should fall back to mismatch-only display when filter is applied', function (): void {
+        // Create test route and endpoint
+        $route = new LaravelRoute(
+            uri: 'api/users',
+            methods: ['GET'],
+            name: 'users.index',
+            action: 'App\Http\Controllers\UserController@index',
+            middleware: ['api']
+        );
+
+        // Create validation result without allRoutes/allEndpoints (filter applied)
+        $validationResult = new ValidationResult(
+            isValid: false,
+            mismatches: [
+                RouteMismatch::missingDocumentation($route),
+            ],
+            warnings: [],
+            statistics: ['total_routes' => 1],
+            allRoutes: null,  // No complete data when filtered
+            allEndpoints: null
+        );
+
+        // Use reflection to access private method
+        $reflection = new ReflectionClass($this->validateCommand);
+        $buildTableDataMethod = $reflection->getMethod('buildTableData');
+
+        $tableData = $buildTableDataMethod->invoke($this->validateCommand, $validationResult);
+
+        // Should only have 1 row (only mismatches shown when filtered)
+        expect($tableData)->toHaveCount(1);
+        expect($tableData[0][0])->toBe('GET');
+        expect($tableData[0][1])->toBe('/api/users');
+        expect($tableData[0][5])->toBe('✗ Missing Doc');
+    });
+
+    it('should show proper source indicators', function (): void {
+        $route = new LaravelRoute(
+            uri: 'api/users',
+            methods: ['GET'],
+            name: 'users.index',
+            action: 'App\Http\Controllers\UserController@index',
+            middleware: ['api']
+        );
+
+        $endpoint = new EndpointDefinition(
+            path: '/api/users',
+            method: 'GET',
+            operationId: 'getUsers'
+        );
+
+        $routeOnlyRoute = new LaravelRoute(
+            uri: 'api/posts',
+            methods: ['POST'],
+            name: 'posts.store',
+            action: 'App\Http\Controllers\PostController@store',
+            middleware: ['api']
+        );
+
+        $endpointOnlyEndpoint = new EndpointDefinition(
+            path: '/api/comments',
+            method: 'GET',
+            operationId: 'getComments'
+        );
+
+        $validationResult = new ValidationResult(
+            isValid: false,
+            mismatches: [
+                RouteMismatch::missingDocumentation($routeOnlyRoute),
+                RouteMismatch::missingImplementation($endpointOnlyEndpoint),
+            ],
+            warnings: [],
+            statistics: [],
+            allRoutes: [$route, $routeOnlyRoute],
+            allEndpoints: [$endpoint, $endpointOnlyEndpoint]
+        );
+
+        $reflection = new ReflectionClass($this->validateCommand);
+        $buildTableDataMethod = $reflection->getMethod('buildTableData');
+
+        $tableData = $buildTableDataMethod->invoke($this->validateCommand, $validationResult);
+
+        expect($tableData)->toHaveCount(3);
+
+        // Find each row by signature and check source
+        foreach ($tableData as $row) {
+            $signature = $row[0] . ':' . $row[1];
+            match ($signature) {
+                'GET:/api/users' => expect($row[4])->toBe('Both'),     // Both route and endpoint
+                'POST:/api/posts' => expect($row[4])->toBe('Laravel'), // Route only
+                'GET:/api/comments' => expect($row[4])->toBe('OpenAPI'), // Endpoint only
+                default => null, // For any unexpected signatures
+            };
+        }
+    });
+});


### PR DESCRIPTION
- Enhanced ValidationResult model to optionally store complete route and endpoint data
- Modified RouteValidator to pass allRoutes/allEndpoints when no filter types specified
- Rewrote ValidateRoutesCommand table building logic with conditional display methods:
  - buildCompleteTableData() for unfiltered results showing all routes/endpoints
  - buildMismatchTableData() for filtered results showing only mismatches
- Added comprehensive status indicators (✓ Match, ✗ Missing Doc, ✗ Missing Impl)
- Added source indicators (Laravel, OpenAPI, Both) to show data origin
- Created extensive test suite ValidateRoutesCommandAllRoutesTest.php with 15 assertions

Fixes issue where route validation command only showed problematic routes instead of providing complete visibility into route-endpoint alignment when no filters are applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When no filters are applied, show a complete table combining framework routes and OpenAPI endpoints; with status, Source (Both/Framework/OpenAPI), parameters, and rows sorted by path and method.
  * Filtered view still supports mismatches-only display with consistent status labels.

* **Tests**
  * Added unit tests for full-table mode, mismatches-only filtering, status derivation, and source indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->